### PR TITLE
:bug: fix auth of transmission miss in flexget

### DIFF
--- a/00.Installation/template/config/flexget.config.yml
+++ b/00.Installation/template/config/flexget.config.yml
@@ -32,6 +32,8 @@ templates:
       path: /home/SCRIPTUSERNAME/transmission/download/
       host: localhost
       port: 9099
+      username: SCRIPTUSERNAME
+      password: SCRIPTPASSWORD
   de:
     deluge:
       path: /home/SCRIPTUSERNAME/deluge/download/


### PR DESCRIPTION
fix auth of transmission miss in flexget config 
so that install script can automatically change the
default setting, and will not cause flexget report
`Username/password for transmission is incorrect. Cannot connect.`

![tim 20181012100755](https://user-images.githubusercontent.com/13842140/46843731-ba912480-ce06-11e8-9d01-e0addbbdadbb.jpg)
